### PR TITLE
MemoryLayout(::AbstractArray)

### DIFF
--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -140,6 +140,8 @@ in memory is unknown.
 Julia's internal linear algebra machinery will automatically (and invisibly)
 dispatch to BLAS and LAPACK routines if the memory layout is compatible.
 """
+@inline MemoryLayout(::AT) where {AT<:AbstractArray} = MemoryLayout(AT)
+
 @inline MemoryLayout(::Type) = UnknownLayout()
 
 @inline MemoryLayout(::Type{<:Number}) = ScalarLayout()

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -140,7 +140,7 @@ in memory is unknown.
 Julia's internal linear algebra machinery will automatically (and invisibly)
 dispatch to BLAS and LAPACK routines if the memory layout is compatible.
 """
-@inline MemoryLayout(::AT) where {AT<:AbstractArray} = MemoryLayout(AT)
+@inline MemoryLayout(A) = MemoryLayout(typeof(A))
 
 @inline MemoryLayout(::Type) = UnknownLayout()
 

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -17,7 +17,7 @@ struct FooNumber <: Number end
 
         A = randn(6)
         @test MemoryLayout(typeof(A)) == MemoryLayout(typeof(Base.ReshapedArray(A,(2,3),()))) == 
-            MemoryLayout(typeof(reinterpret(Float32,A))) == DenseColumnMajor()
+            MemoryLayout(typeof(reinterpret(Float32,A))) == MemoryLayout(A) == DenseColumnMajor()
         
         @test MemoryLayout(typeof(view(A,1:3))) == DenseColumnMajor()
         @test MemoryLayout(typeof(view(A,Base.OneTo(3)))) == DenseColumnMajor()
@@ -27,7 +27,7 @@ struct FooNumber <: Number end
 
         A = randn(6,6)
         V = view(A, 1:3,:)
-        @test MemoryLayout(typeof(V)) == ColumnMajor()
+        @test MemoryLayout(typeof(V)) == MemoryLayout(V) == ColumnMajor()
     end
 
     @testset "adjoint and transpose MemoryLayout" begin

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -13,7 +13,7 @@ struct FooNumber <: Number end
 @testset "MemoryLayout" begin
     @testset "Trivial" begin
         @test MemoryLayout(3.141) == MemoryLayout(Float64) == MemoryLayout(Int) == MemoryLayout(FooNumber) == ScalarLayout()
-        @test MemoryLayout(FooBar(3)) == MemoryLayout(FooBar) == UnknownLayout()
+        @test MemoryLayout(FooBar()) == MemoryLayout(FooBar) == UnknownLayout()
 
         A = randn(6)
         @test MemoryLayout(typeof(A)) == MemoryLayout(typeof(Base.ReshapedArray(A,(2,3),()))) == 

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -12,8 +12,8 @@ struct FooNumber <: Number end
 
 @testset "MemoryLayout" begin
     @testset "Trivial" begin
-        @test MemoryLayout(Float64) == MemoryLayout(Int) == MemoryLayout(FooNumber) == ScalarLayout()
-        @test MemoryLayout(FooBar) == UnknownLayout()
+        @test MemoryLayout(3.141) == MemoryLayout(Float64) == MemoryLayout(Int) == MemoryLayout(FooNumber) == ScalarLayout()
+        @test MemoryLayout(FooBar(3)) == MemoryLayout(FooBar) == UnknownLayout()
 
         A = randn(6)
         @test MemoryLayout(typeof(A)) == MemoryLayout(typeof(Base.ReshapedArray(A,(2,3),()))) == 


### PR DESCRIPTION
This lets `MemoryLayout` act on an instance instead of its type, which is (I think) what its docstring says should work. 