### PR TITLE
Scalar l/rmul! fallbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/lmul.jl
+++ b/src/lmul.jl
@@ -70,6 +70,9 @@ copyto!(dest::AbstractArray, M::Rmul) = _rmul_copyto!(dest, M)
 materialize!(M::Lmul) = LinearAlgebra.lmul!(M.A,M.B)
 materialize!(M::Rmul) = LinearAlgebra.rmul!(M.A,M.B)
 
+materialize!(M::Lmul{ScalarLayout}) = Base.invoke(LinearAlgebra.lmul!, Tuple{Number,AbstractArray}, M.A, M.B)
+materialize!(M::Rmul{<:Any,ScalarLayout}) = Base.invoke(LinearAlgebra.rmul!, Tuple{AbstractArray,Number}, M.A, M.B)
+
 
 
 macro _layoutlmul(Typ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,6 +127,11 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
             @test A\MyMatrix(X) ≈ A\X
         end
     end
+
+    @testset "l/rmul!" begin
+        b = randn(5)
+        @test lmul!(2, MyVector(copy(b))) == rmul!(MyVector(copy(b)), 2) == 2b
+    end
 end
 
 struct MyUpperTriangular{T} <: AbstractMatrix{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,7 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
 
     @testset "l/rmul!" begin
         b = randn(5)
-        @test lmul!(2, MyVector(copy(b))) == rmul!(MyVector(copy(b)), 2) == 2b
+        @test ArrayLayouts.lmul!(2, MyVector(copy(b))) == ArrayLayouts.rmul!(MyVector(copy(b)), 2) == 2b
     end
 end
 


### PR DESCRIPTION
Fixes Stack overflow from `ArrayLayouts.lmul!(::Number, ::AbstractArray)`