### PR TITLE
Allow more general *TridiagonalLayout, improve interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1'
+          - '1.5'
           - '^1.6.0-0'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.5.4"
+version = "0.6"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Compat = "3.16"
 FillArrays = "0.11"
-julia = "1"
+julia = "1.5"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrayLayouts"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.6"
+version = "0.6.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -41,12 +41,7 @@ import LinearAlgebra.BLAS: BlasFloat, BlasReal, BlasComplex
 
 import FillArrays: AbstractFill, getindex_value, axes_print_matrix_row
 
-if VERSION < v"1.2-"
-    import Base: has_offset_axes
-    require_one_based_indexing(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
-else
-    import Base: require_one_based_indexing
-end
+import Base: require_one_based_indexing
 
 export materialize, materialize!, MulAdd, muladd!, Ldiv, Rdiv, Lmul, Rmul, Dot,
         lmul, rmul, mul, ldiv, rdiv, mul, MemoryLayout, AbstractStridedLayout,
@@ -208,10 +203,8 @@ copyto!(dest::SubArray{<:Any,2,<:LayoutArray}, src::AdjOrTrans{<:Any,<:LayoutArr
 copyto!(dest::SubArray{<:Any,2,<:LayoutMatrix}, src::SubArray{<:Any,2,<:AdjOrTrans{<:Any,<:LayoutArray}}) = _copyto!(dest, src)
 copyto!(dest::AbstractMatrix, src::SubArray{<:Any,2,<:AdjOrTrans{<:Any,<:LayoutArray}}) = _copyto!(dest, src)
 # ambiguity from sparsematrix.jl
-if VERSION ≥ v"1.5"
-    copyto!(dest::LayoutMatrix, src::SparseArrays.AbstractSparseMatrixCSC) = _copyto!(dest, src)
-    copyto!(dest::SubArray{<:Any,2,<:LayoutMatrix}, src::SparseArrays.AbstractSparseMatrixCSC) = _copyto!(dest, src)
-end
+copyto!(dest::LayoutMatrix, src::SparseArrays.AbstractSparseMatrixCSC) = _copyto!(dest, src)
+copyto!(dest::SubArray{<:Any,2,<:LayoutMatrix}, src::SparseArrays.AbstractSparseMatrixCSC) = _copyto!(dest, src)
 
 # avoid bad copy in Base
 Base.map(::typeof(copy), D::Diagonal{<:LayoutArray}) = Diagonal(map(copy, D.diag))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -22,7 +22,6 @@ copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diagonaldata(M.B))
 
 
 
-
 # Diagonal multiplication never changes structure
 similar(M::Rmul{<:Any,<:DiagonalLayout}, ::Type{T}, axes) where T = similar(M.A, T, axes)
 # equivalent to rescaling
@@ -46,3 +45,12 @@ copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout}) = Diagonal(M.A.diag .* inv.(M.B
 copy(M::Rdiv{<:Any,<:DiagonalLayout}) = M.A .* inv.(permutedims(M.B.diag))
 copy(M::Rdiv{<:Any,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A .* inv(getindex_value(M.B.diag)) 
 copy(M::Rdiv{<:DiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = Diagonal(M.A.diag .* inv(getindex_value(M.B.diag)))
+
+
+## bi/tridiagonal copy
+copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout}) = convert(Bidiagonal, M.A) * M.B
+copy(M::Lmul{<:DiagonalLayout,<:BidiagonalLayout}) = M.A * convert(Bidiagonal, M.B)
+copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout}) = convert(Tridiagonal, M.A) * M.B
+copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout}) = M.A * convert(Tridiagonal, M.B)
+copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout}) = convert(SymTridiagonal, M.A) * M.B
+copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout}) = M.A * convert(SymTridiagonal, M.B)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -16,9 +16,9 @@ function materialize!(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}})
 end
 
 
-copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = Diagonal(diag(M.A) .* diag(M.B))
-copy(M::Lmul{<:DiagonalLayout}) = diag(M.A) .* M.B
-copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diag(M.B))
+copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = Diagonal(diagonaldata(M.A) .* diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout}) = diagonaldata(M.A) .* M.B
+copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diagonaldata(M.B))
 
 
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -16,9 +16,9 @@ function materialize!(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout}})
 end
 
 
-copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = Diagonal(diagonaldata(M.A) .* diagonaldata(M.B))
-copy(M::Lmul{<:DiagonalLayout}) = diagonaldata(M.A) .* M.B
-copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout,<:DiagonalLayout}) = Diagonal(diag(M.A) .* diag(M.B))
+copy(M::Lmul{<:DiagonalLayout}) = diag(M.A) .* M.B
+copy(M::Rmul{<:Any,<:DiagonalLayout}) = M.A .* permutedims(diag(M.B))
 
 
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -54,3 +54,11 @@ copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout}) = convert(Tridiagonal, M.A) 
 copy(M::Lmul{<:DiagonalLayout,<:TridiagonalLayout}) = M.A * convert(Tridiagonal, M.B)
 copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout}) = convert(SymTridiagonal, M.A) * M.B
 copy(M::Lmul{<:DiagonalLayout,<:SymTridiagonalLayout}) = M.A * convert(SymTridiagonal, M.B)
+
+
+copy(M::Rmul{<:BidiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:BidiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Rmul{<:TridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:TridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B
+copy(M::Rmul{<:SymTridiagonalLayout,<:DiagonalLayout{<:AbstractFillLayout}}) = M.A * getindex_value(diagonaldata(M.B))
+copy(M::Lmul{<:DiagonalLayout{<:AbstractFillLayout},<:SymTridiagonalLayout}) = getindex_value(diagonaldata(M.A)) * M.B

--- a/src/ldiv.jl
+++ b/src/ldiv.jl
@@ -95,12 +95,7 @@ __ldiv!(_, F, B) = LinearAlgebra.ldiv!(F, B)
 @inline materialize!(M::Ldiv) = _ldiv!(M.A, M.B)
 @inline materialize!(M::Rdiv) = ldiv!(M.B', M.A')'
 @inline copyto!(dest::AbstractArray, M::Rdiv) = copyto!(dest', Ldiv(M.B', M.A'))'
-
-if VERSION ≥ v"1.1-pre"
-    @inline copyto!(dest::AbstractArray, M::Ldiv) = _ldiv!(dest, M.A, M.B)
-else
-    @inline copyto!(dest::AbstractArray, M::Ldiv) = _ldiv!(dest, M.A, copy(M.B))
-end
+@inline copyto!(dest::AbstractArray, M::Ldiv) = _ldiv!(dest, M.A, copy(M.B))
 
 const MatLdivVec{styleA, styleB, T, V} = Ldiv{styleA, styleB, <:AbstractMatrix{T}, <:AbstractVector{V}}
 const MatLdivMat{styleA, styleB, T, V} = Ldiv{styleA, styleB, <:AbstractMatrix{T}, <:AbstractMatrix{V}}

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -586,9 +586,11 @@ transposelayout(ml::SymTridiagonalLayout) = ml
 transposelayout(ml::TridiagonalLayout) = ml
 transposelayout(ml::ConjLayout{DiagonalLayout}) = ml
 
-triangularlayout(::Type{<:TriangularLayout{UPLO,'N'}}, ::TridiagonalLayout{ML}) where {UPLO,ML} = BidiagonalLayout{ML}()
-triangularlayout(::Type{<:TriangularLayout{UPLO,'N'}}, ::TridiagonalLayout{FillLayout}) where UPLO = BidiagonalLayout{FillLayout}()
-triangularlayout(::Type{<:TriangularLayout{UPLO,'U'}}, ::TridiagonalLayout{FillLayout}) where UPLO = BidiagonalLayout{FillLayout}()
+triangularlayout(::Type{<:TriangularLayout{'L','N'}}, ::TridiagonalLayout{DL,D,DU}) where {DL,D,DU} = BidiagonalLayout{D,DL}()
+triangularlayout(::Type{<:TriangularLayout{'U','N'}}, ::TridiagonalLayout{DL,D,DU}) where {UPLO,DL,D,DU} = BidiagonalLayout{D,DU}()
+triangularlayout(::Type{<:TriangularLayout{'L','N'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) = BidiagonalLayout{FillLayout,FillLayout}()
+triangularlayout(::Type{<:TriangularLayout{'U','N'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) = BidiagonalLayout{FillLayout,FillLayout}()
+triangularlayout(::Type{<:TriangularLayout{UPLO,'U'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) where UPLO = BidiagonalLayout{FillLayout,FillLayout}()
 
 bidiagonaluplo(::Union{UpperTriangular,UnitUpperTriangular}) = 'U'
 bidiagonaluplo(::Union{LowerTriangular,UnitLowerTriangular}) = 'L'
@@ -599,8 +601,8 @@ adjointlayout(::Type{<:Real}, ml::SymTridiagonalLayout) = ml
 adjointlayout(::Type{<:Real}, ml::TridiagonalLayout) = ml
 adjointlayout(::Type{<:Real}, ml::BidiagonalLayout) = ml
 
-symmetriclayout(B::BidiagonalLayout{ML}) where ML = SymTridiagonalLayout{ML}()
-hermitianlayout(::Type{<:Real}, B::BidiagonalLayout{ML}) where ML = SymTridiagonalLayout{ML}()
+symmetriclayout(B::BidiagonalLayout{DV,EV}) where {DV,EV} = SymTridiagonalLayout{DV,EV}()
+hermitianlayout(::Type{<:Real}, B::BidiagonalLayout{DV,EV}) where {DV,EV} = SymTridiagonalLayout{DV,EV}()
 hermitianlayout(_, B::BidiagonalLayout) = HermitianLayout{typeof(B)}()
 
 subdiag(D::Transpose) = supdiag(parent(D))

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -598,12 +598,9 @@ supdiag(U::Union{UnitUpperTriangular,UpperTriangular}) = supdiag(triangulardata(
 subdiag(U::Union{UnitLowerTriangular,LowerTriangular}) = subdiag(triangulardata(U))
 
 adjointlayout(::Type{<:Real}, ml::SymTridiagonalLayout) = ml
-adjointlayout(::Type{<:Real}, ml::TridiagonalLayout) = ml
+adjointlayout(::Type{<:Real}, ::TridiagonalLayout{DL,D,DU}) where {DL,D,DU} = TridiagonalLayout{DU,D,DL}()
 adjointlayout(::Type{<:Real}, ml::BidiagonalLayout) = ml
 
-symmetriclayout(B::BidiagonalLayout{DV,EV}) where {DV,EV} = SymTridiagonalLayout{DV,EV}()
-hermitianlayout(::Type{<:Real}, B::BidiagonalLayout{DV,EV}) where {DV,EV} = SymTridiagonalLayout{DV,EV}()
-hermitianlayout(_, B::BidiagonalLayout) = HermitianLayout{typeof(B)}()
 
 subdiag(D::Transpose) = supdiag(parent(D))
 supdiag(D::Transpose) = subdiag(parent(D))

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -659,10 +659,14 @@ colsupport(::ZerosLayout, A, _) = 1:0
 rowsupport(::DiagonalLayout, _, k) = isempty(k) ? (1:0) : minimum(k):maximum(k)
 colsupport(::DiagonalLayout, _, j) = isempty(j) ? (1:0) : minimum(j):maximum(j)
 
-colsupport(::BidiagonalLayout, A, j) = 
+function colsupport(::BidiagonalLayout, A, j)
+    isempty(j) && return 1:0
     bidiagonaluplo(A) == 'L' ? (minimum(j):min(size(A,1),maximum(j)+1)) : (max(minimum(j)-1,1):maximum(j))
-rowsupport(::BidiagonalLayout, A, j) = 
+end
+function rowsupport(::BidiagonalLayout, A, j)
+    isempty(j) && return 1:0
     bidiagonaluplo(A) == 'U' ? (minimum(j):min(size(A,2),maximum(j)+1)) : (max(minimum(j)-1,1):maximum(j))
+end
 
 colsupport(::AbstractTridiagonalLayout, A, j) = max(minimum(j)-1,1):min(size(A,1),maximum(j)+1)
 rowsupport(::AbstractTridiagonalLayout, A, j) = max(minimum(j)-1,1):min(size(A,2),maximum(j)+1)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -321,8 +321,8 @@ end
 function _bidiag_backsub!(M)
     A,b = M.A, M.B
     N = last(colsupport(b,1))
-    dv = diag(A)
-    ev = supdiag(A)
+    dv = diagonaldata(A)
+    ev = supdiagonaldata(A)
     b[N] = bj1 = dv[N]\b[N]
     
     @inbounds for j = (N - 1):-1:1
@@ -341,8 +341,8 @@ end
 
 function _bidiag_forwardsub!(M)
     A, b = M.A, M.B
-    dv = diag(A)
-    ev = subdiag(A)
+    dv = diagonaldata(A)
+    ev = subdiagonaldata(A)
     N = length(b)
     b[1] = bj1 = dv[1]\b[1]
     @inbounds for j = 2:N

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -321,8 +321,8 @@ end
 function _bidiag_backsub!(M)
     A,b = M.A, M.B
     N = last(colsupport(b,1))
-    dv = diagonaldata(A)
-    ev = supdiagonaldata(A)
+    dv = diag(A)
+    ev = supdiag(A)
     b[N] = bj1 = dv[N]\b[N]
     
     @inbounds for j = (N - 1):-1:1
@@ -341,8 +341,8 @@ end
 
 function _bidiag_forwardsub!(M)
     A, b = M.A, M.B
-    dv = diagonaldata(A)
-    ev = subdiagonaldata(A)
+    dv = diag(A)
+    ev = subdiag(A)
     N = length(b)
     b[1] = bj1 = dv[1]\b[1]
     @inbounds for j = 2:N

--- a/test/test_layoutarray.jl
+++ b/test/test_layoutarray.jl
@@ -171,15 +171,14 @@ MemoryLayout(::Type{MyVector}) = DenseColumnMajor()
         C = randn(ComplexF64,5,5)
         @test ArrayLayouts.lmul!(2, Hermitian(copy(C))) == ArrayLayouts.rmul!(Hermitian(copy(C)), 2) == 2Hermitian(C)
 
-        if VERSION ≥ v"1.5"
-            @test ldiv!(2, deepcopy(b)) == rdiv!(deepcopy(b), 2) == 2\b
-            @test ldiv!(2, deepcopy(A)) == rdiv!(deepcopy(A), 2) == 2\A
-            @test ldiv!(2, deepcopy(A)') == rdiv!(deepcopy(A)', 2) == 2\A'
-            @test ldiv!(2, transpose(deepcopy(A))) == rdiv!(transpose(deepcopy(A)), 2) == 2\transpose(A)
-            @test ldiv!(2, Symmetric(deepcopy(A))) == rdiv!(Symmetric(deepcopy(A)), 2) == 2\Symmetric(A)
-            @test ldiv!(2, Hermitian(deepcopy(A))) == rdiv!(Hermitian(deepcopy(A)), 2) == 2\Hermitian(A)
-            @test ArrayLayouts.ldiv!(2, Hermitian(copy(C))) == ArrayLayouts.rdiv!(Hermitian(copy(C)), 2) == 2\Hermitian(C)
-        end
+        
+        @test ldiv!(2, deepcopy(b)) == rdiv!(deepcopy(b), 2) == 2\b
+        @test ldiv!(2, deepcopy(A)) == rdiv!(deepcopy(A), 2) == 2\A
+        @test ldiv!(2, deepcopy(A)') == rdiv!(deepcopy(A)', 2) == 2\A'
+        @test ldiv!(2, transpose(deepcopy(A))) == rdiv!(transpose(deepcopy(A)), 2) == 2\transpose(A)
+        @test ldiv!(2, Symmetric(deepcopy(A))) == rdiv!(Symmetric(deepcopy(A)), 2) == 2\Symmetric(A)
+        @test ldiv!(2, Hermitian(deepcopy(A))) == rdiv!(Hermitian(deepcopy(A)), 2) == 2\Hermitian(A)
+        @test ArrayLayouts.ldiv!(2, Hermitian(copy(C))) == ArrayLayouts.rdiv!(Hermitian(copy(C)), 2) == 2\Hermitian(C)
     end
 
     @testset "pow/I" begin

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -6,7 +6,7 @@ import ArrayLayouts: MemoryLayout, DenseRowMajor, DenseColumnMajor, StridedLayou
                         UnitLowerTriangularLayout, ScalarLayout, UnknownLayout,
                         hermitiandata, symmetricdata, FillLayout, ZerosLayout, OnesLayout,
                         DiagonalLayout, TridiagonalLayout, SymTridiagonalLayout, colsupport, rowsupport,
-                        diagonaldata, subdiagonaldata, supdiagonaldata, BidiagonalLayout, bidiagonaluplo
+                        subdiag, supdiag, BidiagonalLayout, bidiagonaluplo
 
 struct FooBar end
 struct FooNumber <: Number end
@@ -117,12 +117,12 @@ struct FooNumber <: Number end
         @test bidiagonaluplo(Bl) == bidiagonaluplo(Adjoint(Bu)) == 'L'
         @test bidiagonaluplo(Bu) == bidiagonaluplo(Adjoint(Bl)) == 'U'
 
-        @test diagonaldata(T) == diagonaldata(T') == diagonaldata(S) == diagonaldata(Bl) == diagonaldata(Bu)
-        @test supdiagonaldata(T) == subdiagonaldata(Adjoint(T)) == subdiagonaldata(Transpose(T)) == 
-                    supdiagonaldata(S) == subdiagonaldata(S) == 
-                    supdiagonaldata(Bu) == subdiagonaldata(Adjoint(Bu)) == subdiagonaldata(Transpose(Bu))
-        @test subdiagonaldata(T) == supdiagonaldata(Adjoint(T)) == supdiagonaldata(Transpose(T)) == 
-                subdiagonaldata(Bl) == supdiagonaldata(Adjoint(Bl)) == supdiagonaldata(Transpose(Bl)) ==
+        @test diag(T) == diag(T') == diag(S) == diag(Bl) == diag(Bu)
+        @test supdiag(T) == subdiag(Adjoint(T)) == subdiag(Transpose(T)) == 
+                    supdiag(S) == subdiag(S) == 
+                    supdiag(Bu) == subdiag(Adjoint(Bu)) == subdiag(Transpose(Bu))
+        @test subdiag(T) == supdiag(Adjoint(T)) == supdiag(Transpose(T)) == 
+                subdiag(Bl) == supdiag(Adjoint(Bl)) == supdiag(Transpose(Bl)) ==
                 T.dl
 
         @test colsupport(T,3) == rowsupport(T,3) == colsupport(S,3) == rowsupport(S,3) == 2:4
@@ -141,12 +141,12 @@ struct FooNumber <: Number end
             L = LowerTriangular(T)
             @test MemoryLayout(U) isa BidiagonalLayout{DenseColumnMajor}
             @test MemoryLayout(L) isa BidiagonalLayout{DenseColumnMajor}
-            @test diagonaldata(U) == diagonaldata(L) == diagonaldata(T)
-            @test subdiagonaldata(L) == subdiagonaldata(T)
-            @test supdiagonaldata(U) == supdiagonaldata(T)
+            @test diag(U) == diag(L) == diag(T)
+            @test subdiag(L) == subdiag(T)
+            @test supdiag(U) == supdiag(T)
             @test bidiagonaluplo(U) == 'U'
             @test bidiagonaluplo(L) == 'L'
-            @test_throws MethodError subdiagonaldata(U)
+            @test_throws MethodError subdiag(U)
         end
     end
 
@@ -246,8 +246,8 @@ struct FooNumber <: Number end
         @test MemoryLayout(Sc) isa SymTridiagonalLayout
         @test MemoryLayout(Hc) isa HermitianLayout
 
-        @test diagonaldata(S) == diagonaldata(B)
-        @test subdiagonaldata(S) == supdiagonaldata(S) == supdiagonaldata(B)
+        @test diag(S) == diag(B)
+        @test subdiag(S) == supdiag(S) == supdiag(B)
 
         @test colsupport(S,3) == colsupport(H,3) == colsupport(Sc,3) == colsupport(Hc,3) == 2:4
         @test rowsupport(S,3) == rowsupport(H,3) == rowsupport(Sc,3) == rowsupport(Hc,3) == 2:4

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -6,7 +6,7 @@ import ArrayLayouts: MemoryLayout, DenseRowMajor, DenseColumnMajor, StridedLayou
                         UnitLowerTriangularLayout, ScalarLayout, UnknownLayout,
                         hermitiandata, symmetricdata, FillLayout, ZerosLayout, OnesLayout,
                         DiagonalLayout, TridiagonalLayout, SymTridiagonalLayout, colsupport, rowsupport,
-                        subdiag, supdiag, BidiagonalLayout, bidiagonaluplo
+                        diagonaldata, subdiagonaldata, supdiagonaldata, BidiagonalLayout, bidiagonaluplo
 
 struct FooBar end
 struct FooNumber <: Number end
@@ -117,12 +117,12 @@ struct FooNumber <: Number end
         @test bidiagonaluplo(Bl) == bidiagonaluplo(Adjoint(Bu)) == 'L'
         @test bidiagonaluplo(Bu) == bidiagonaluplo(Adjoint(Bl)) == 'U'
 
-        @test diag(T) == diag(T') == diag(S) == diag(Bl) == diag(Bu)
-        @test supdiag(T) == subdiag(Adjoint(T)) == subdiag(Transpose(T)) == 
-                    supdiag(S) == subdiag(S) == 
-                    supdiag(Bu) == subdiag(Adjoint(Bu)) == subdiag(Transpose(Bu))
-        @test subdiag(T) == supdiag(Adjoint(T)) == supdiag(Transpose(T)) == 
-                subdiag(Bl) == supdiag(Adjoint(Bl)) == supdiag(Transpose(Bl)) ==
+        @test diagonaldata(T) == diagonaldata(T') == diagonaldata(S) == diagonaldata(Bl) == diagonaldata(Bu)
+        @test supdiagonaldata(T) == subdiagonaldata(Adjoint(T)) == subdiagonaldata(Transpose(T)) == 
+                    supdiagonaldata(S) == subdiagonaldata(S) == 
+                    supdiagonaldata(Bu) == subdiagonaldata(Adjoint(Bu)) == subdiagonaldata(Transpose(Bu))
+        @test subdiagonaldata(T) == supdiagonaldata(Adjoint(T)) == supdiagonaldata(Transpose(T)) == 
+                subdiagonaldata(Bl) == supdiagonaldata(Adjoint(Bl)) == supdiagonaldata(Transpose(Bl)) ==
                 T.dl
 
         @test colsupport(T,3) == rowsupport(T,3) == colsupport(S,3) == rowsupport(S,3) == 2:4
@@ -141,12 +141,12 @@ struct FooNumber <: Number end
             L = LowerTriangular(T)
             @test MemoryLayout(U) isa BidiagonalLayout{DenseColumnMajor,DenseColumnMajor}
             @test MemoryLayout(L) isa BidiagonalLayout{DenseColumnMajor,DenseColumnMajor}
-            @test diag(U) == diag(L) == diag(T)
-            @test subdiag(L) == subdiag(T)
-            @test supdiag(U) == supdiag(T)
+            @test diagonaldata(U) == diagonaldata(L) == diagonaldata(T)
+            @test subdiagonaldata(L) == subdiagonaldata(T)
+            @test supdiagonaldata(U) == supdiagonaldata(T)
             @test bidiagonaluplo(U) == 'U'
             @test bidiagonaluplo(L) == 'L'
-            @test_throws MethodError subdiag(U)
+            @test_throws MethodError subdiagonaldata(U)
         end
     end
 
@@ -246,8 +246,8 @@ struct FooNumber <: Number end
         @test MemoryLayout(Sc) isa SymTridiagonalLayout
         @test MemoryLayout(Hc) isa HermitianLayout
 
-        @test diag(S) == diag(B)
-        @test subdiag(S) == supdiag(S) == supdiag(B)
+        @test diagonaldata(S) == diagonaldata(B)
+        @test subdiagonaldata(S) == supdiagonaldata(S) == supdiagonaldata(B)
 
         @test colsupport(S,3) == colsupport(H,3) == colsupport(Sc,3) == colsupport(Hc,3) == 2:4
         @test rowsupport(S,3) == rowsupport(H,3) == rowsupport(Sc,3) == rowsupport(Hc,3) == 2:4

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -139,8 +139,8 @@ struct FooNumber <: Number end
         @testset "Triangular of Tridiagonal" begin
             U = UpperTriangular(T)
             L = LowerTriangular(T)
-            @test MemoryLayout(U) isa BidiagonalLayout{DenseColumnMajor}
-            @test MemoryLayout(L) isa BidiagonalLayout{DenseColumnMajor}
+            @test MemoryLayout(U) isa BidiagonalLayout{DenseColumnMajor,DenseColumnMajor}
+            @test MemoryLayout(L) isa BidiagonalLayout{DenseColumnMajor,DenseColumnMajor}
             @test diag(U) == diag(L) == diag(T)
             @test subdiag(L) == subdiag(T)
             @test supdiag(U) == supdiag(T)
@@ -304,6 +304,12 @@ struct FooNumber <: Number end
         v = SubArray(Fill(1,10),(1:3,))
         @test ArrayLayouts.sub_materialize(v) ≡ Fill(1,3)
         @test ArrayLayouts._copyto!(Vector{Float64}(undef,3), v) == ones(3)
+
+        T = Tridiagonal(Fill(1,10), Fill(2,11), Fill(3,10))
+        @test MemoryLayout(UpperTriangular(T)) isa BidiagonalLayout{FillLayout,FillLayout}
+        @test MemoryLayout(LowerTriangular(T)) isa BidiagonalLayout{FillLayout,FillLayout}
+        @test MemoryLayout(UnitUpperTriangular(T)) isa BidiagonalLayout{FillLayout,FillLayout}
+        @test MemoryLayout(UnitLowerTriangular(T)) isa BidiagonalLayout{FillLayout,FillLayout}
     end
 
     @testset "Triangular col/rowsupport" begin

--- a/test/test_muladd.jl
+++ b/test/test_muladd.jl
@@ -1,4 +1,4 @@
-using ArrayLayouts, FillArrays, Random, Test
+using ArrayLayouts, FillArrays, Random, LinearAlgebra, Test
 import ArrayLayouts: DenseColumnMajor, AbstractStridedLayout, AbstractColumnMajor, DiagonalLayout, mul, Mul, zero!
 
 Random.seed!(0)
@@ -668,5 +668,22 @@ Random.seed!(0)
         @test eltype(MulAdd(A,B)) == eltype(B)
         @test copy(MulAdd(A,B̃)) == A*B̃
         @test eltype(MulAdd(A,B̃)) == eltype(B̃)
+    end
+
+    @testset "Bidiagonal" begin
+        BidiagU = Bidiagonal(randn(5), randn(4), :U)
+        BidiagL = Bidiagonal(randn(5), randn(4), :L)
+        Tridiag = Tridiagonal(randn(4), randn(5), randn(4))
+        SymTri = SymTridiagonal(randn(5), randn(4))
+        Diag = Diagonal(randn(5))
+        @test typeof(mul(BidiagU,Diag)) <: Bidiagonal
+        @test typeof(mul(BidiagL,Diag)) <: Bidiagonal
+        @test typeof(mul(Tridiag,Diag)) <: Tridiagonal
+        @test typeof(mul(SymTri,Diag))  <: Tridiagonal
+
+        @test typeof(mul(BidiagU,Diag)) <: Bidiagonal
+        @test typeof(mul(Diag,BidiagL)) <: Bidiagonal
+        @test typeof(mul(Diag,Tridiag)) <: Tridiagonal
+        @test typeof(mul(Diag,SymTri))  <: Tridiagonal
     end
 end


### PR DESCRIPTION
This is to support a more general `*Tridiagonal` in LazyBandedMatrices.jl with types differing.