### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/ArrayLayouts.jl
+++ b/src/ArrayLayouts.jl
@@ -102,7 +102,7 @@ end
 # work-around issue with complex conjugation of pointer
 unsafe_convert(::Type{Ptr{T}}, Ac::Adjoint{<:Complex}) where T<:Complex = unsafe_convert(ConjPtr{T}, parent(Ac))
 unsafe_convert(::Type{ConjPtr{T}}, Ac::Adjoint{<:Complex}) where T<:Complex = unsafe_convert(Ptr{T}, parent(Ac))
-function unsafe_convert(::Type{ConjPtr{T}}, V::SubArray{T,2}) where {T,N,P}
+function unsafe_convert(::Type{ConjPtr{T}}, V::SubArray{T,2}) where {T}
     kr, jr = parentindices(V)
     unsafe_convert(Ptr{T}, view(parent(V)', jr, kr))
 end

--- a/src/factorizations.jl
+++ b/src/factorizations.jl
@@ -114,9 +114,9 @@ struct AdjQRPackedQLayout{SLAY,TLAY} <: AbstractQLayout end
 struct QRCompactWYQLayout{SLAY,TLAY} <: AbstractQLayout end
 struct AdjQRCompactWYQLayout{SLAY,TLAY} <: AbstractQLayout end
 
-MemoryLayout(::Type{<:LinearAlgebra.QRPackedQ{<:Any,S}}) where {S,T} =
+MemoryLayout(::Type{<:LinearAlgebra.QRPackedQ{<:Any,S}}) where {S} =
     QRPackedQLayout{typeof(MemoryLayout(S)),DenseColumnMajor}()
-MemoryLayout(::Type{<:LinearAlgebra.QRCompactWYQ{<:Any,S}}) where {S,T} =
+MemoryLayout(::Type{<:LinearAlgebra.QRCompactWYQ{<:Any,S}}) where {S} =
     QRCompactWYQLayout{typeof(MemoryLayout(S)),DenseColumnMajor}()
 
 adjointlayout(::Type, ::QRPackedQLayout{SLAY,TLAY}) where {SLAY,TLAY} = AdjQRPackedQLayout{SLAY,TLAY}()

--- a/src/lmul.jl
+++ b/src/lmul.jl
@@ -19,7 +19,7 @@ for Typ in (:Lmul, :Rmul)
         size(M::$Typ) = map(length,axes(M))
         axes(M::$Typ) = (axes(M.A,1),axes(M.B,2))
 
-        similar(M::$Typ, ::Type{T}, axes) where {T,N} = similar(Array{T}, axes)
+        similar(M::$Typ, ::Type{T}, axes) where {T} = similar(Array{T}, axes)
         similar(M::$Typ, ::Type{T}) where T = similar(M, T, axes(M))
         similar(M::$Typ) = similar(M, eltype(M))
     end

--- a/src/memorylayout.jl
+++ b/src/memorylayout.jl
@@ -591,7 +591,7 @@ transposelayout(ml::TridiagonalLayout) = ml
 transposelayout(ml::ConjLayout{DiagonalLayout}) = ml
 
 triangularlayout(::Type{<:TriangularLayout{'L','N'}}, ::TridiagonalLayout{DL,D,DU}) where {DL,D,DU} = BidiagonalLayout{D,DL}()
-triangularlayout(::Type{<:TriangularLayout{'U','N'}}, ::TridiagonalLayout{DL,D,DU}) where {UPLO,DL,D,DU} = BidiagonalLayout{D,DU}()
+triangularlayout(::Type{<:TriangularLayout{'U','N'}}, ::TridiagonalLayout{DL,D,DU}) where {DL,D,DU} = BidiagonalLayout{D,DU}()
 triangularlayout(::Type{<:TriangularLayout{'L','N'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) = BidiagonalLayout{FillLayout,FillLayout}()
 triangularlayout(::Type{<:TriangularLayout{'U','N'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) = BidiagonalLayout{FillLayout,FillLayout}()
 triangularlayout(::Type{<:TriangularLayout{UPLO,'U'}}, ::TridiagonalLayout{FillLayout,FillLayout,FillLayout}) where UPLO = BidiagonalLayout{FillLayout,FillLayout}()

--- a/src/mul.jl
+++ b/src/mul.jl
@@ -80,7 +80,7 @@ The Default is `MulAdd`. Note that the lowered type must overload `copyto!` and 
 """
 mulreduce(M::Mul) = MulAdd(M)
 
-similar(M::Mul, ::Type{T}, axes) where {T,N} = similar(mulreduce(M), T, axes)
+similar(M::Mul, ::Type{T}, axes) where {T} = similar(mulreduce(M), T, axes)
 similar(M::Mul, ::Type{T}) where T = similar(mulreduce(M), T)
 similar(M::Mul) = similar(mulreduce(M))
 

--- a/src/muladd.jl
+++ b/src/muladd.jl
@@ -38,9 +38,9 @@ length(M::MulAdd) = prod(size(M))
 size(M::MulAdd) = map(length,axes(M))
 axes(M::MulAdd) = axes(M.C)
 
-similar(M::MulAdd, ::Type{T}, axes) where {T,N} = similar(Array{T}, axes)
-similar(M::MulAdd{<:DualLayout,<:Any,<:Any,<:Any,<:Adjoint}, ::Type{T}, axes) where {T,N} = similar(Array{T}, axes[2])'
-similar(M::MulAdd{<:DualLayout,<:Any,<:Any,<:Any,<:Transpose}, ::Type{T}, axes) where {T,N} = transpose(similar(Array{T}, axes[2]))
+similar(M::MulAdd, ::Type{T}, axes) where {T} = similar(Array{T}, axes)
+similar(M::MulAdd{<:DualLayout,<:Any,<:Any,<:Any,<:Adjoint}, ::Type{T}, axes) where {T} = similar(Array{T}, axes[2])'
+similar(M::MulAdd{<:DualLayout,<:Any,<:Any,<:Any,<:Transpose}, ::Type{T}, axes) where {T} = transpose(similar(Array{T}, axes[2]))
 similar(M::MulAdd, ::Type{T}) where T = similar(M, T, axes(M))
 similar(M::MulAdd) = similar(M, eltype(M))
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -184,13 +184,13 @@ BLAS.trmm!('R', 'L', 'T', UNIT, one(T), transpose(triangulardata(A)), x)
 end
 
 @inline function materialize!(M::BlasMatRmulMat{<:AbstractStridedLayout,
-                                                <:TriangularLayout{'L',UNIT,<:ConjLayout{<:AbstractRowMajor}},T}) where {UPLO,UNIT,T<:BlasComplex}
+                                                <:TriangularLayout{'L',UNIT,<:ConjLayout{<:AbstractRowMajor}},T}) where {UNIT,T<:BlasComplex}
     x,A = M.A,M.B
     BLAS.trmm!('R', 'U', 'C', UNIT, one(T), triangulardata(A)', x)
 end
 
 @inline function materialize!(M::BlasMatRmulMat{<:AbstractStridedLayout,
-                                                <:TriangularLayout{'U',UNIT,<:ConjLayout{<:AbstractRowMajor}},T}) where {UPLO,UNIT,T<:BlasComplex}
+                                                <:TriangularLayout{'U',UNIT,<:ConjLayout{<:AbstractRowMajor}},T}) where {UNIT,T<:BlasComplex}
 x,A = M.A,M.B
 BLAS.trmm!('R', 'L', 'C', UNIT, one(T), triangulardata(A)', x)
 end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.